### PR TITLE
Elixir 1 5 1 buildpack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: elixir
 
 elixir:
-  - 1.4.2
+  - 1.5.1
 otp_release:
-  - 19.3
+  - 20.0
 services:
   - postgresql
 before_script:

--- a/app.json
+++ b/app.json
@@ -24,7 +24,7 @@
   },
   "buildpacks": [
     {
-      "url": "https://github.com/HashNuke/heroku-buildpack-elixir.git#560e1bd7d22edf8e4d0c6706dfbcaa94fa60c397"
+      "url": "https://github.com/ondreian/heroku-buildpack-elixir.git#6344b1cf0e4b1179e6ab77ff8a662d04c25ae342"
     },
     {
       "url": "https://github.com/gjaldon/heroku-buildpack-phoenix-static.git#45e77b3b64996422e846d375a6f57e79d212488f"

--- a/apps/montreal_elixir/mix.exs
+++ b/apps/montreal_elixir/mix.exs
@@ -8,7 +8,7 @@ defmodule MontrealElixir.Mixfile do
      config_path: "../../config/config.exs",
      deps_path: "../../deps",
      lockfile: "../../mix.lock",
-     elixir: "~> 1.4",
+     elixir: "~> 1.5.1",
      elixirc_paths: elixirc_paths(Mix.env),
      start_permanent: Mix.env == :prod,
      aliases: aliases(),

--- a/apps/montreal_elixir_web/mix.exs
+++ b/apps/montreal_elixir_web/mix.exs
@@ -8,7 +8,7 @@ defmodule MontrealElixir.Web.Mixfile do
      config_path: "../../config/config.exs",
      deps_path: "../../deps",
      lockfile: "../../mix.lock",
-     elixir: "~> 1.4",
+     elixir: "~> 1.5.1",
      elixirc_paths: elixirc_paths(Mix.env),
      compilers: [:phoenix, :gettext] ++ Mix.compilers,
      start_permanent: Mix.env == :prod,

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,3 +1,3 @@
-erlang_version=19.3
-elixir_version=1.4.2
+erlang_version=20.0
+elixir_version=1.5.1
 always_rebuild=false


### PR DESCRIPTION
Solves #9 

This PR changes the app to use Elixir 1.5.1 and Erlang 20.0. I could not find a buildpack with Erlang 20.1 yet.

The app builds properly in dev, test and production (https://fast-citadel-66492.herokuapp.com/).

To deploy on Heroku, you need to change the buildpack like so:

```
$ heroku buildpacks:set "https://github.com/ondreian/heroku-buildpack-elixir"
```

Note that compiling Phoenix 1.3.0 app on Elixir 1.5.1 results in a lot deprecation warnings. Even though some of the dependencies (like cowboy) are already fully compatible with 1.5.1, Phoenix 1.3.0 still depends on older versions so we probably have to wait for Phoenix 1.3.1 to resolve 1.5.1 deprecations.
