### PR TITLE
Fix column width

### DIFF
--- a/apps/montreal_elixir_web/lib/montreal_elixir_web/templates/page/index.html.eex
+++ b/apps/montreal_elixir_web/lib/montreal_elixir_web/templates/page/index.html.eex
@@ -4,7 +4,7 @@
 </div>
 
 <div class="row marketing">
-  <div class="col-lg-6">
+  <div class="col-sm-6">
     <h4>Monthly Meetup</h4>
     <ul>
       <li>
@@ -25,7 +25,7 @@
     </ul>
   </div>
 
-  <div class="col-lg-6">
+  <div class="col-sm-6">
     <h4>Resources</h4>
     <ul>
       <li>


### PR DESCRIPTION
### Description of the Change

On iPad, the columns were not side by side.  On small devices, the blocks are on top of each other, which is ok (would need to use col-xs-6 if we wanted to have the columns side by side).