### PR TITLE
Dynamically display the header "Next event" or Most recent event"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 /deps
 erl_crash.dump
 *.ez
-
+*~
 /config/dev.secret.exs

--- a/apps/montreal_elixir_web/lib/montreal_elixir_web/templates/page/index.html.eex
+++ b/apps/montreal_elixir_web/lib/montreal_elixir_web/templates/page/index.html.eex
@@ -1,7 +1,7 @@
 <%= if @next_meetup do %>
   <div class="row marketing">
     <div class="col-sm-12">
-      <h4>Next event / most recent event</h4>
+      <h4><%= next_or_most_recent_event(@next_meetup.utc_datetime) %></h4>
     </div>
 
     <div class="col-sm-6">

--- a/apps/montreal_elixir_web/lib/montreal_elixir_web/views/date_time_helpers.ex
+++ b/apps/montreal_elixir_web/lib/montreal_elixir_web/views/date_time_helpers.ex
@@ -21,4 +21,24 @@ defmodule MontrealElixirWeb.DateTimeHelpers do
     |> Timex.to_datetime("America/Montreal")
     |> Timex.format!("{WDshort} {Mfull} {D} at {h12}:{m} {AM}")
   end
+
+  @doc """
+  Places "Next Event" in the header if the datetime is in the future from now.
+  Otherwise places "Most recent event" in the header.
+
+  ## Examples
+
+      iex> {:ok, d, 0} = DateTime.from_iso8601("2017-01-02 15:16:17Z"); next_or_most_recent_event(d)
+      "Most recent event"
+      iex> {:ok, d, 0} = DateTime.from_iso8601("2030-05-07 15:16:17Z"); next_or_most_recent_event(d)
+      "Next event"
+  """
+  def next_or_most_recent_event(utc_datetime) do
+    if Timex.before?(utc_datetime, Timex.now) do
+      "Most recent event"
+    else
+      "Next event"
+    end
+  end
+
 end

--- a/apps/montreal_elixir_web/test/montreal_elixir_web/controllers/page_controller_test.exs
+++ b/apps/montreal_elixir_web/test/montreal_elixir_web/controllers/page_controller_test.exs
@@ -17,7 +17,7 @@ defmodule MontrealElixirWeb.PageControllerTest do
       conn = get conn, "/"
       resp = html_response(conn, 200)
 
-      assert resp =~ "Next event"
+      assert resp =~ "Next event" || resp =~ "Most recent event"
       assert resp =~ "Wed October 11 at 6:30 PM"
       assert resp =~ "490 rue de la Gauchetiere Ouest"
     end

--- a/apps/montreal_elixir_web/test/montreal_elixir_web/views/date_time_helpers_test.exs
+++ b/apps/montreal_elixir_web/test/montreal_elixir_web/views/date_time_helpers_test.exs
@@ -1,0 +1,5 @@
+defmodule MontrealElixirWeb.DateTimeHelpersTest do
+  use ExUnit.Case, async: true
+  import MontrealElixirWeb.DateTimeHelpers
+  doctest MontrealElixirWeb.DateTimeHelpers
+end


### PR DESCRIPTION
### Description of the Change

The headers change depending on whether the latest event obtained
from the meetup page is taking place before or after the present
datetime. "Most recent event" is displayed if before and "Future
event" is displayed if after.

Include test file (date_time_helpers_test.exs) to run
the doctests in date_time_helpers.ex.

Modify page_controller_test.exs to pass under the new changes.

Solves Issue #22. 