### PR TITLE
Add SweetIQ as event sponsor

### DIFF
--- a/apps/montreal_elixir_web/lib/montreal_elixir_web/templates/layout/app.html.eex
+++ b/apps/montreal_elixir_web/lib/montreal_elixir_web/templates/layout/app.html.eex
@@ -28,7 +28,8 @@
         <h4>Sponsors</h4>
         <ul>
           <li><a target="_blank" href="http://www.civilcode.io">CivilCode Inc.</a> (community sponsor)</li>
-          <li><a target="_blank" href="http://www.shopify.ca">Shopify</a> (event sponsor)</li>
+          <li><a target="_blank" href="https://sweetiq.com/">SweetIQ</a> (event sponsor)</li>
+          <li><a target="_blank" href="http://www.shopify.ca">Shopify</a> (past event sponsor)</li>
         </ul>
       </footer>
     </div> <!-- /container -->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Modify sponsors section to include SweetIQ as the current event sponsor, also marked Shopify as past event sponsor, not sure if we want to add this or just keep it as it was since in the meetup page it's marked as past venue sponsor.