### PR TITLE
Add link to YT videos

### DIFF
--- a/apps/montreal_elixir_web/lib/montreal_elixir_web/templates/page/index.html.eex
+++ b/apps/montreal_elixir_web/lib/montreal_elixir_web/templates/page/index.html.eex
@@ -43,7 +43,9 @@
     <ul class="list-unstyled">
     <%= for video <- @new_videos do %>
       <li>
-        <img src="<%= video.img_url %>"><br/>
+        <a href="<%= video.url %>" target="_blank">
+          <img src="<%= video.img_url %>"><br/>
+        </a>
         <%= video.title %><br/>
         <em><%= video.published_at %></em>
       </li>

--- a/apps/social_feeds/config/config.exs
+++ b/apps/social_feeds/config/config.exs
@@ -3,7 +3,8 @@
 use Mix.Config
 
 config :social_feeds, :youtube_api_client, [
-  youtube_url: "https://www.googleapis.com/youtube/v3",
+  youtube_api_url: "https://www.googleapis.com/youtube/v3",
+  youtube_url: "https://youtube.com",
   channel_id: "UCftyx5k7K_0a3wIGRtE2YQw"
 ]
 

--- a/apps/social_feeds/lib/social_feeds/youtube/api_client.ex
+++ b/apps/social_feeds/lib/social_feeds/youtube/api_client.ex
@@ -56,14 +56,17 @@ defmodule SocialFeeds.Youtube.ApiClient do
   defp to_video(video_map) do
     %Video{
       title: video_map["snippet"]["title"],
+      url: youtube_watch_url() <> "?v=" <> video_map["contentDetails"]["upload"]["videoId"],
       img_url: video_map["snippet"]["thumbnails"]["default"]["url"],
       published_at: video_map["snippet"]["publishedAt"]
     }
   end
 
   defp youtube_activities_url, do: base_url() <> "/activities"
+  defp youtube_watch_url, do: public_url() <> "/watch"
 
-  defp base_url, do: Application.get_env(:social_feeds, :youtube_api_client)[:youtube_url]
+  defp base_url, do: Application.get_env(:social_feeds, :youtube_api_client)[:youtube_api_url]
+  defp public_url, do: Application.get_env(:social_feeds, :youtube_api_client)[:youtube_url]
   defp channel_id, do: Application.get_env(:social_feeds, :youtube_api_client)[:channel_id]
   defp api_key, do: Application.get_env(:social_feeds, :youtube_api_client)[:api_key]
 

--- a/apps/social_feeds/lib/social_feeds/youtube/video.ex
+++ b/apps/social_feeds/lib/social_feeds/youtube/video.ex
@@ -2,5 +2,5 @@ defmodule SocialFeeds.Youtube.Video do
   @moduledoc """
   Struct keeping video attributes.
   """
-  defstruct [:title, :img_url, :published_at]
+  defstruct [:title, :url, :img_url, :published_at]
 end

--- a/apps/social_feeds/test/youtube/api_client_test.exs
+++ b/apps/social_feeds/test/youtube/api_client_test.exs
@@ -15,6 +15,7 @@ defmodule SocialFeeds.Youtube.ApiClientTest do
       video = %Video{
         title: "Phoenix 1.3 and Contexts",
         published_at: "2017-09-19T12:23:32.000Z",
+        url: "https://youtube.com/watch?v=y25Suot7vto",
         img_url: "https://i.ytimg.com/vi/y25Suot7vto/default.jpg"
       }
       resp = ApiClient.get_new_videos()


### PR DESCRIPTION
Closes #30 

**Change**
Youtube's  API does not include a complete url for each item. In order to add a proper url, I added a new key `:id` to `SocialFeeds.Youtube.Video` struct; that way the url to the video can be constructed on template by `href="https://youtube.com/watch?v=<% video.id %>"`

