### PR TITLE
Fix latest meetup event not showing up

### DIFF
--- a/apps/social_feeds/lib/social_feeds/meetup/api_client.ex
+++ b/apps/social_feeds/lib/social_feeds/meetup/api_client.ex
@@ -24,9 +24,8 @@ defmodule SocialFeeds.Meetup.ApiClient do
   def get_next_event do
     # Note: due to a bug in Meetup API, we need to get the full list.
     # Specifying a page size of 1 does not return the most recent or upcoming meetup.
-    %{scroll: "future_or_past", page: 200}
+    %{scroll: "next_upcoming", page: 1, desc: "true"}
     |> get_events()
-    |> Enum.reverse
     |> List.first()
   end
 

--- a/apps/social_feeds/lib/social_feeds/meetup/api_client.ex
+++ b/apps/social_feeds/lib/social_feeds/meetup/api_client.ex
@@ -22,8 +22,11 @@ defmodule SocialFeeds.Meetup.ApiClient do
 
   """
   def get_next_event do
-    %{scroll: "future_or_past", page: 1}
+    # Note: due to a bug in Meetup API, we need to get the full list.
+    # Specifying a page size of 1 does not return the most recent or upcoming meetup.
+    %{scroll: "future_or_past", page: 200}
     |> get_events()
+    |> Enum.reverse
     |> List.first()
   end
 

--- a/apps/social_feeds/test/api_clients/meetup_api_http_client.exs
+++ b/apps/social_feeds/test/api_clients/meetup_api_http_client.exs
@@ -7,7 +7,7 @@ defmodule SocialFeeds.Test.MeetupApiHttpClient do
   def request(url) do
     url = to_string(url)
     cond do
-      String.contains?(url, "scroll=future_or_past") -> {:ok, {[], [], @upcoming_meetups_json}}
+      String.contains?(url, "scroll=next_upcoming") -> {:ok, {[], [], @upcoming_meetups_json}}
       String.contains?(url, "error=true") -> {:error, {}}
       true -> {:ok, {[], [], @meetups_json}}
     end


### PR DESCRIPTION
Meetup API is broken for scroll option 'future_or_past'.  WIth a page size of 1, we do not get the latest or upcoming event, as documented.

### Description of the Change

The feature of getting the most recent past event or upcoming event no longer works.  Trying the API in Meetup's console (https://secure.meetup.com/meetup_api/console/?path=/:urlname/events) shows the same problem.  We should open up an issue at Meetup.

Short-term workaround: ask for all events, and take the last one in the list.