### PR TITLE
Add Mirego as the current event sponsor

### DIFF
--- a/apps/montreal_elixir_web/lib/montreal_elixir_web/templates/layout/app.html.eex
+++ b/apps/montreal_elixir_web/lib/montreal_elixir_web/templates/layout/app.html.eex
@@ -28,7 +28,8 @@
         <h4>Sponsors</h4>
         <ul>
           <li><a target="_blank" href="http://www.civilcode.io">CivilCode Inc.</a> (community sponsor)</li>
-          <li><a target="_blank" href="https://sweetiq.com/">SweetIQ</a> (event sponsor)</li>
+          <li><a target="_blank" href="https://www.mirego.com">Mirego</a> (event sponsor)</li>
+          <li><a target="_blank" href="https://sweetiq.com">SweetIQ</a> (past event sponsor)</li>
           <li><a target="_blank" href="http://www.shopify.ca">Shopify</a> (past event sponsor)</li>
         </ul>
       </footer>


### PR DESCRIPTION
### Requirements

fixes #49

### Description of the Change

Add the Mirego link in the Sponsors section of the landing page