### PR TITLE
Fix the :httpc.request/1 pattern match

### DIFF
--- a/apps/social_feeds/lib/social_feeds/youtube/api_client.ex
+++ b/apps/social_feeds/lib/social_feeds/youtube/api_client.ex
@@ -48,7 +48,7 @@ defmodule SocialFeeds.Youtube.ApiClient do
     Logger.info "YouTube API: requesting #{redact_sensitive_data(url)}"
 
     case @http.request(String.to_charlist(url)) do
-      {:ok, {{"HTTP/1.1", 200, "OK"}, _, body}} -> Poison.decode!(body)["items"]
+      {:ok, {{_http_version, 200, _reason}, _headers, body}} -> Poison.decode!(body)["items"]
       _ -> []
     end
   end


### PR DESCRIPTION
### Requirements

In the previous PR, `mix format` was applied to the updated files before pushing the last commit, which changed the `'` to `"` and broke the `:httpc.request/1` result pattern match.

### Description of the Change

Based on the [doc](http://www.erlang.org/doc/man/httpc.html#request-1), ’request/1’ returns à _tuple_ with the following format :

```
request(Url) ->  {ok, Result} | {error, Reason}

# Types
Result = {status_line(), headers(), Body}
Reason = term()
…
status_line() = {http_version(), status_code(), reason_phrase()}
http_version() = string(), for example, "HTTP/1.1"
status_code() = integer()
reason_phrase() = string()
…
```

Testing the request in `iex` reveals the `http_version` and `reason_phrase` are returned in _single quote_. I could have simply changed it, but running `mix format` in the future would obviously break the same line again. Since the match is not relevant (_other than the status code_), I think it's better to simple ignore those element of the _3-tuple_.

```
iex(3)> :httpc.request(String.to_charlist("https://www.googleapis.com/youtube/v3/activities?channelId=UCftyx5k7K_0a3wIGRtE2YQw&key=…&maxResults=3&part=snippet%2CcontentDetails"))
{:ok,
 {{'HTTP/1.1', 200, 'OK'},
  [
    {'cache-control', 'private, max-age=0, must-revalidate, no-transform'},
    {'content-type', 'application/json; charset=UTF-8'},
    …  
  ],
  '{\n "kind": "youtube#activityListResponse",\n "etag":  …}'
}}
```