### PR TITLE
Enforce mix format on CI and provide base formatter config

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 [
   inputs: ["mix.exs", "{apps,config}/**/*.{ex,exs}"],
-  line_length: 200
+  line_length: 100
 ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+[
+  inputs: ["mix.exs", "{apps,config}/**/*.{ex,exs}"],
+  line_length: 200
+]

--- a/apps/montreal_elixir/config/config.exs
+++ b/apps/montreal_elixir/config/config.exs
@@ -7,8 +7,7 @@ config :montreal_elixir, MontrealElixir.Repo,
   url: System.get_env("DATABASE_URL"),
   pool_size: String.to_integer(System.get_env("DATABASE_POOL_SIZE") || "10")
 
-config :montreal_elixir, :meetup_api_client,
-  meetup_url: "https://api.meetup.com/montrealelixir"
+config :montreal_elixir, :meetup_api_client, meetup_url: "https://api.meetup.com/montrealelixir"
 
 # Import environment specific config.
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/apps/montreal_elixir/config/prod.exs
+++ b/apps/montreal_elixir/config/prod.exs
@@ -1,4 +1,3 @@
 use Mix.Config
 
-config :montreal_elixir, MontrealElixir.Repo,
-  ssl: true
+config :montreal_elixir, MontrealElixir.Repo, ssl: true

--- a/apps/montreal_elixir/config/staging.exs
+++ b/apps/montreal_elixir/config/staging.exs
@@ -1,4 +1,3 @@
 use Mix.Config
 
-config :montreal_elixir, MontrealElixir.Repo,
-  ssl: true
+config :montreal_elixir, MontrealElixir.Repo, ssl: true

--- a/apps/montreal_elixir/config/travis.exs
+++ b/apps/montreal_elixir/config/travis.exs
@@ -6,4 +6,5 @@ config :montreal_elixir, MontrealElixir.Repo,
   database: "montreal_elixir_test",
   pool: Ecto.Adapters.SQL.Sandbox
 
-config :montreal_elixir, :meetup_api_client, http_client: MontrealElixir.SocialFeeds.Test.MeetupApiHttpClient
+config :montreal_elixir, :meetup_api_client,
+  http_client: MontrealElixir.SocialFeeds.Test.MeetupApiHttpClient

--- a/apps/montreal_elixir/config/travis.exs
+++ b/apps/montreal_elixir/config/travis.exs
@@ -6,5 +6,4 @@ config :montreal_elixir, MontrealElixir.Repo,
   database: "montreal_elixir_test",
   pool: Ecto.Adapters.SQL.Sandbox
 
-config :montreal_elixir, :meetup_api_client,
-  http_client: MontrealElixir.SocialFeeds.Test.MeetupApiHttpClient
+config :montreal_elixir, :meetup_api_client, http_client: MontrealElixir.SocialFeeds.Test.MeetupApiHttpClient

--- a/apps/montreal_elixir/lib/montreal_elixir/application.ex
+++ b/apps/montreal_elixir/lib/montreal_elixir/application.ex
@@ -12,8 +12,12 @@ defmodule MontrealElixir.Application do
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
-    Supervisor.start_link([
-      worker(MontrealElixir.Repo, []),
-    ], strategy: :one_for_one, name: MontrealElixir.Supervisor)
+    Supervisor.start_link(
+      [
+        worker(MontrealElixir.Repo, [])
+      ],
+      strategy: :one_for_one,
+      name: MontrealElixir.Supervisor
+    )
   end
 end

--- a/apps/montreal_elixir/mix.exs
+++ b/apps/montreal_elixir/mix.exs
@@ -2,37 +2,37 @@ defmodule MontrealElixir.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :montreal_elixir,
-     version: "0.0.1",
-     build_path: "../../_build",
-     config_path: "../../config/config.exs",
-     deps_path: "../../deps",
-     lockfile: "../../mix.lock",
-     elixir: "~> 1.6.4",
-     elixirc_paths: elixirc_paths(Mix.env),
-     start_permanent: Mix.env == :prod,
-     aliases: aliases(),
-     deps: deps()]
+    [
+      app: :montreal_elixir,
+      version: "0.0.1",
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.6.4",
+      elixirc_paths: elixirc_paths(Mix.env()),
+      start_permanent: Mix.env() == :prod,
+      aliases: aliases(),
+      deps: deps()
+    ]
   end
 
   # Configuration for the OTP application.
   #
   # Type `mix help compile.app` for more information.
   def application do
-    [mod: {MontrealElixir.Application, []},
-     extra_applications: [:logger, :runtime_tools]]
+    [mod: {MontrealElixir.Application, []}, extra_applications: [:logger, :runtime_tools]]
   end
 
   # Specifies which paths to compile per environment.
   defp elixirc_paths(:test), do: ["lib", "test/support"]
-  defp elixirc_paths(_),     do: ["lib"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Specifies your project dependencies.
   #
   # Type `mix help deps` for examples and options.
   defp deps do
-    [{:postgrex, ">= 0.0.0"},
-     {:ecto, "~> 2.1"}]
+    [{:postgrex, ">= 0.0.0"}, {:ecto, "~> 2.1"}]
   end
 
   # Aliases are shortcuts or tasks specific to the current project.
@@ -42,8 +42,6 @@ defmodule MontrealElixir.Mixfile do
   #
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
-    ["ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
-     "ecto.reset": ["ecto.drop", "ecto.setup"],
-     "test": ["ecto.create --quiet", "ecto.migrate", "test"]]
+    ["ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"], "ecto.reset": ["ecto.drop", "ecto.setup"], test: ["ecto.create --quiet", "ecto.migrate", "test"]]
   end
 end

--- a/apps/montreal_elixir/mix.exs
+++ b/apps/montreal_elixir/mix.exs
@@ -42,6 +42,10 @@ defmodule MontrealElixir.Mixfile do
   #
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
-    ["ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"], "ecto.reset": ["ecto.drop", "ecto.setup"], test: ["ecto.create --quiet", "ecto.migrate", "test"]]
+    [
+      "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+      "ecto.reset": ["ecto.drop", "ecto.setup"],
+      test: ["ecto.create --quiet", "ecto.migrate", "test"]
+    ]
   end
 end

--- a/apps/montreal_elixir_web/config/dev.exs
+++ b/apps/montreal_elixir_web/config/dev.exs
@@ -11,7 +11,14 @@ config :montreal_elixir_web, MontrealElixirWeb.Endpoint,
   debug_errors: true,
   code_reloader: true,
   check_origin: false,
-  watchers: [node: ["node_modules/brunch/bin/brunch", "watch", "--stdin", cd: Path.expand("../assets", __DIR__)]]
+  watchers: [
+    node: [
+      "node_modules/brunch/bin/brunch",
+      "watch",
+      "--stdin",
+      cd: Path.expand("../assets", __DIR__)
+    ]
+  ]
 
 # ## SSL Support
 #

--- a/apps/montreal_elixir_web/lib/montreal_elixir_web.ex
+++ b/apps/montreal_elixir_web/lib/montreal_elixir_web.ex
@@ -27,8 +27,9 @@ defmodule MontrealElixirWeb do
 
   def view do
     quote do
-      use Phoenix.View, root: "lib/montreal_elixir_web/templates",
-                        namespace: MontrealElixirWeb
+      use Phoenix.View,
+        root: "lib/montreal_elixir_web/templates",
+        namespace: MontrealElixirWeb
 
       # Import convenience functions from controllers
       import Phoenix.Controller, only: [get_csrf_token: 0, get_flash: 2, view_module: 1]

--- a/apps/montreal_elixir_web/lib/montreal_elixir_web/application.ex
+++ b/apps/montreal_elixir_web/lib/montreal_elixir_web/application.ex
@@ -11,7 +11,7 @@ defmodule MontrealElixirWeb.Application do
       # Start the endpoint when the application starts
       supervisor(MontrealElixirWeb.Endpoint, []),
       # Start your own worker by calling: MontrealElixirWeb.Worker.start_link(arg1, arg2, arg3)
-      worker(MontrealElixirWeb.TwitterTimelineListener, []),
+      worker(MontrealElixirWeb.TwitterTimelineListener, [])
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/apps/montreal_elixir_web/lib/montreal_elixir_web/channels/twitter_timeline_channel.ex
+++ b/apps/montreal_elixir_web/lib/montreal_elixir_web/channels/twitter_timeline_channel.ex
@@ -9,7 +9,7 @@ defmodule MontrealElixirWeb.TwitterTimelineChannel do
   end
 
   def handle_info({:after_join, _msg}, socket) do
-    latest_tweets = Twitter.Timeline.tweets
+    latest_tweets = Twitter.Timeline.tweets()
     push(socket, "updated_list", %{tweets: latest_tweets})
 
     {:noreply, socket}

--- a/apps/montreal_elixir_web/lib/montreal_elixir_web/channels/user_socket.ex
+++ b/apps/montreal_elixir_web/lib/montreal_elixir_web/channels/user_socket.ex
@@ -2,10 +2,10 @@ defmodule MontrealElixirWeb.UserSocket do
   use Phoenix.Socket
 
   ## Channels
-  channel "twitter_timeline", MontrealElixirWeb.TwitterTimelineChannel
+  channel("twitter_timeline", MontrealElixirWeb.TwitterTimelineChannel)
 
   ## Transports
-  transport :websocket, Phoenix.Transports.WebSocket, timeout: 45_000
+  transport(:websocket, Phoenix.Transports.WebSocket, timeout: 45_000)
   # transport :longpoll, Phoenix.Transports.LongPoll
 
   # Socket params are passed from the client and can

--- a/apps/montreal_elixir_web/lib/montreal_elixir_web/controllers/page_controller.ex
+++ b/apps/montreal_elixir_web/lib/montreal_elixir_web/controllers/page_controller.ex
@@ -3,12 +3,12 @@ defmodule MontrealElixirWeb.PageController do
 
   def index(conn, _params) do
     next_meetup = SocialFeeds.get_next_meetup_event()
-    new_videos  = SocialFeeds.get_new_yt_videos()
+    new_videos = SocialFeeds.get_new_yt_videos()
 
-    render conn, "index.html", next_meetup: next_meetup, new_videos: new_videos
+    render(conn, "index.html", next_meetup: next_meetup, new_videos: new_videos)
   end
 
   def mockup(conn, _params) do
-    render conn, "mockup.html"
+    render(conn, "mockup.html")
   end
 end

--- a/apps/montreal_elixir_web/lib/montreal_elixir_web/endpoint.ex
+++ b/apps/montreal_elixir_web/lib/montreal_elixir_web/endpoint.ex
@@ -7,7 +7,13 @@ defmodule MontrealElixirWeb.Endpoint do
   #
   # You should set gzip to true if you are running phoenix.digest
   # when deploying your static files in production.
-  plug(Plug.Static, at: "/", from: :montreal_elixir_web, gzip: false, only: ~w(css fonts images js favicon.ico robots.txt))
+  plug(
+    Plug.Static,
+    at: "/",
+    from: :montreal_elixir_web,
+    gzip: false,
+    only: ~w(css fonts images js favicon.ico robots.txt)
+  )
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.

--- a/apps/montreal_elixir_web/lib/montreal_elixir_web/endpoint.ex
+++ b/apps/montreal_elixir_web/lib/montreal_elixir_web/endpoint.ex
@@ -1,44 +1,46 @@
 defmodule MontrealElixirWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :montreal_elixir_web
 
-  socket "/socket", MontrealElixirWeb.UserSocket
+  socket("/socket", MontrealElixirWeb.UserSocket)
 
   # Serve at "/" the static files from "priv/static" directory.
   #
   # You should set gzip to true if you are running phoenix.digest
   # when deploying your static files in production.
-  plug Plug.Static,
-    at: "/", from: :montreal_elixir_web, gzip: false,
-    only: ~w(css fonts images js favicon.ico robots.txt)
+  plug(Plug.Static, at: "/", from: :montreal_elixir_web, gzip: false, only: ~w(css fonts images js favicon.ico robots.txt))
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.
   if code_reloading? do
-    socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
-    plug Phoenix.LiveReloader
-    plug Phoenix.CodeReloader
+    socket("/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket)
+    plug(Phoenix.LiveReloader)
+    plug(Phoenix.CodeReloader)
   end
 
-  plug Plug.RequestId
-  plug Plug.Logger
+  plug(Plug.RequestId)
+  plug(Plug.Logger)
 
-  plug Plug.Parsers,
+  plug(
+    Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
     json_decoder: Poison
+  )
 
-  plug Plug.MethodOverride
-  plug Plug.Head
+  plug(Plug.MethodOverride)
+  plug(Plug.Head)
 
   # The session will be stored in the cookie and signed,
   # this means its contents can be read but not tampered with.
   # Set :encryption_salt if you would also like to encrypt it.
-  plug Plug.Session,
+  plug(
+    Plug.Session,
     store: :cookie,
     key: "_montreal_elixir_web_key",
     signing_salt: "e9FWV39l"
+  )
 
-  plug MontrealElixirWeb.Router
+  plug(MontrealElixirWeb.Router)
 
   @doc """
   Callback invoked for dynamically configuring the endpoint.

--- a/apps/montreal_elixir_web/lib/montreal_elixir_web/router.ex
+++ b/apps/montreal_elixir_web/lib/montreal_elixir_web/router.ex
@@ -2,22 +2,23 @@ defmodule MontrealElixirWeb.Router do
   use MontrealElixirWeb, :router
 
   pipeline :browser do
-    plug :accepts, ["html"]
-    plug :fetch_session
-    plug :fetch_flash
-    plug :protect_from_forgery
-    plug :put_secure_browser_headers
+    plug(:accepts, ["html"])
+    plug(:fetch_session)
+    plug(:fetch_flash)
+    plug(:protect_from_forgery)
+    plug(:put_secure_browser_headers)
   end
 
   pipeline :api do
-    plug :accepts, ["json"]
+    plug(:accepts, ["json"])
   end
 
   scope "/", MontrealElixirWeb do
-    pipe_through :browser # Use the default browser stack
+    # Use the default browser stack
+    pipe_through(:browser)
 
-    get "/", PageController, :index
-    get "/mockup", PageController, :mockup
+    get("/", PageController, :index)
+    get("/mockup", PageController, :mockup)
   end
 
   # Other scopes may use custom stacks.

--- a/apps/montreal_elixir_web/lib/montreal_elixir_web/views/date_time_helpers.ex
+++ b/apps/montreal_elixir_web/lib/montreal_elixir_web/views/date_time_helpers.ex
@@ -34,11 +34,10 @@ defmodule MontrealElixirWeb.DateTimeHelpers do
       "Next event"
   """
   def next_or_most_recent_event(utc_datetime) do
-    if Timex.before?(utc_datetime, Timex.now) do
+    if Timex.before?(utc_datetime, Timex.now()) do
       "Most recent event"
     else
       "Next event"
     end
   end
-
 end

--- a/apps/montreal_elixir_web/lib/montreal_elixir_web/views/error_helpers.ex
+++ b/apps/montreal_elixir_web/lib/montreal_elixir_web/views/error_helpers.ex
@@ -9,8 +9,8 @@ defmodule MontrealElixirWeb.ErrorHelpers do
   Generates tag for inlined form input errors.
   """
   def error_tag(form, field) do
-    Enum.map(Keyword.get_values(form.errors, field), fn (error) ->
-      content_tag :span, translate_error(error), class: "help-block"
+    Enum.map(Keyword.get_values(form.errors, field), fn error ->
+      content_tag(:span, translate_error(error), class: "help-block")
     end)
   end
 

--- a/apps/montreal_elixir_web/lib/montreal_elixir_web/views/error_view.ex
+++ b/apps/montreal_elixir_web/lib/montreal_elixir_web/views/error_view.ex
@@ -12,6 +12,6 @@ defmodule MontrealElixirWeb.ErrorView do
   # In case no render clause matches or no
   # template is found, let's render it as 500
   def template_not_found(_template, assigns) do
-    render "500.html", assigns
+    render("500.html", assigns)
   end
 end

--- a/apps/montreal_elixir_web/mix.exs
+++ b/apps/montreal_elixir_web/mix.exs
@@ -2,31 +2,32 @@ defmodule MontrealElixirWeb.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :montreal_elixir_web,
-     version: "0.0.1",
-     build_path: "../../_build",
-     config_path: "../../config/config.exs",
-     deps_path: "../../deps",
-     lockfile: "../../mix.lock",
-     elixir: "~> 1.6.4",
-     elixirc_paths: elixirc_paths(Mix.env),
-     compilers: [:phoenix, :gettext] ++ Mix.compilers,
-     start_permanent: Mix.env == :prod,
-     aliases: aliases(),
-     deps: deps()]
+    [
+      app: :montreal_elixir_web,
+      version: "0.0.1",
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.6.4",
+      elixirc_paths: elixirc_paths(Mix.env()),
+      compilers: [:phoenix, :gettext] ++ Mix.compilers(),
+      start_permanent: Mix.env() == :prod,
+      aliases: aliases(),
+      deps: deps()
+    ]
   end
 
   # Configuration for the OTP application.
   #
   # Type `mix help compile.app` for more information.
   def application do
-    [mod: {MontrealElixirWeb.Application, []},
-     extra_applications: [:logger, :runtime_tools]]
+    [mod: {MontrealElixirWeb.Application, []}, extra_applications: [:logger, :runtime_tools]]
   end
 
   # Specifies which paths to compile per environment.
   defp elixirc_paths(:test), do: ["lib", "test/support"]
-  defp elixirc_paths(_),     do: ["lib"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Specifies your project dependencies.
   #
@@ -52,6 +53,6 @@ defmodule MontrealElixirWeb.Mixfile do
   #
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
-    ["test": ["ecto.create --quiet", "ecto.migrate", "test"]]
+    [test: ["ecto.create --quiet", "ecto.migrate", "test"]]
   end
 end

--- a/apps/montreal_elixir_web/test/montreal_elixir_web/controllers/page_controller_test.exs
+++ b/apps/montreal_elixir_web/test/montreal_elixir_web/controllers/page_controller_test.exs
@@ -8,13 +8,13 @@ defmodule MontrealElixirWeb.PageControllerTest do
 
     @tag :capture_log
     test "shows About section", %{conn: conn} do
-      conn = get conn, "/"
+      conn = get(conn, "/")
       assert html_response(conn, 200) =~ "About Montreal Elixir"
     end
 
     @tag :capture_log
     test "shows the next meetup from Meetup.com", %{conn: conn} do
-      conn = get conn, "/"
+      conn = get(conn, "/")
       resp = html_response(conn, 200)
 
       assert resp =~ "Next event" || resp =~ "Most recent event"
@@ -24,7 +24,7 @@ defmodule MontrealElixirWeb.PageControllerTest do
 
     @tag :capture_log
     test "shows new videos from YT channel", %{conn: conn} do
-      conn = get conn, "/"
+      conn = get(conn, "/")
       resp = html_response(conn, 200)
 
       assert resp =~ "New Videos"

--- a/apps/montreal_elixir_web/test/montreal_elixir_web/views/error_view_test.exs
+++ b/apps/montreal_elixir_web/test/montreal_elixir_web/views/error_view_test.exs
@@ -5,17 +5,14 @@ defmodule MontrealElixirWeb.ErrorViewTest do
   import Phoenix.View
 
   test "renders 404.html" do
-    assert render_to_string(MontrealElixirWeb.ErrorView, "404.html", []) ==
-           "Page not found"
+    assert render_to_string(MontrealElixirWeb.ErrorView, "404.html", []) == "Page not found"
   end
 
   test "render 500.html" do
-    assert render_to_string(MontrealElixirWeb.ErrorView, "500.html", []) ==
-           "Internal server error"
+    assert render_to_string(MontrealElixirWeb.ErrorView, "500.html", []) == "Internal server error"
   end
 
   test "render any other" do
-    assert render_to_string(MontrealElixirWeb.ErrorView, "505.html", []) ==
-           "Internal server error"
+    assert render_to_string(MontrealElixirWeb.ErrorView, "505.html", []) == "Internal server error"
   end
 end

--- a/apps/montreal_elixir_web/test/montreal_elixir_web/views/page_view_test.exs
+++ b/apps/montreal_elixir_web/test/montreal_elixir_web/views/page_view_test.exs
@@ -3,8 +3,7 @@ defmodule MontrealElixirWeb.PageViewTest do
   import Phoenix.View
 
   test "renders index.html if no next_meetup", %{conn: conn} do
-    content = render_to_string(MontrealElixirWeb.PageView, "index.html",
-                               conn: conn, next_meetup: nil, new_videos: [])
+    content = render_to_string(MontrealElixirWeb.PageView, "index.html", conn: conn, next_meetup: nil, new_videos: [])
 
     assert String.contains?(content, "About Montreal Elixir")
     refute String.contains?(content, "Next event")

--- a/apps/montreal_elixir_web/test/montreal_elixir_web/views/page_view_test.exs
+++ b/apps/montreal_elixir_web/test/montreal_elixir_web/views/page_view_test.exs
@@ -3,7 +3,14 @@ defmodule MontrealElixirWeb.PageViewTest do
   import Phoenix.View
 
   test "renders index.html if no next_meetup", %{conn: conn} do
-    content = render_to_string(MontrealElixirWeb.PageView, "index.html", conn: conn, next_meetup: nil, new_videos: [])
+    content =
+      render_to_string(
+        MontrealElixirWeb.PageView,
+        "index.html",
+        conn: conn,
+        next_meetup: nil,
+        new_videos: []
+      )
 
     assert String.contains?(content, "About Montreal Elixir")
     refute String.contains?(content, "Next event")

--- a/apps/montreal_elixir_web/test/support/channel_case.ex
+++ b/apps/montreal_elixir_web/test/support/channel_case.ex
@@ -27,9 +27,11 @@ defmodule MontrealElixirWeb.ChannelCase do
 
   setup tags do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(MontrealElixir.Repo)
+
     unless tags[:async] do
       Ecto.Adapters.SQL.Sandbox.mode(MontrealElixir.Repo, {:shared, self()})
     end
+
     :ok
   end
 end

--- a/apps/montreal_elixir_web/test/support/conn_case.ex
+++ b/apps/montreal_elixir_web/test/support/conn_case.ex
@@ -28,9 +28,11 @@ defmodule MontrealElixirWeb.ConnCase do
 
   setup tags do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(MontrealElixir.Repo)
+
     unless tags[:async] do
       Ecto.Adapters.SQL.Sandbox.mode(MontrealElixir.Repo, {:shared, self()})
     end
+
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
 end

--- a/apps/social_feeds/config/config.exs
+++ b/apps/social_feeds/config/config.exs
@@ -1,11 +1,10 @@
 use Mix.Config
 
-config :social_feeds, :youtube_api_client, [
+config :social_feeds, :youtube_api_client,
   api_key: System.get_env("YOUTUBE_API_KEY"),
   youtube_api_url: "https://www.googleapis.com/youtube/v3",
   youtube_url: "https://youtube.com",
   channel_id: "UCftyx5k7K_0a3wIGRtE2YQw"
-]
 
 # Import environment specific config.
 import_config "#{Mix.env()}.exs"

--- a/apps/social_feeds/config/test.exs
+++ b/apps/social_feeds/config/test.exs
@@ -1,8 +1,6 @@
 use Mix.Config
 
 # Configure SocialFeeds with mocked HTTP clients
-config :social_feeds, :meetup_api_client,
-  http_client: SocialFeeds.Test.MeetupApiHttpClient
+config :social_feeds, :meetup_api_client, http_client: SocialFeeds.Test.MeetupApiHttpClient
 
-config :social_feeds, :youtube_api_client,
-  http_client: SocialFeeds.Test.YoutubeApiHttpClient
+config :social_feeds, :youtube_api_client, http_client: SocialFeeds.Test.YoutubeApiHttpClient

--- a/apps/social_feeds/lib/social_feeds.ex
+++ b/apps/social_feeds/lib/social_feeds.ex
@@ -26,9 +26,7 @@ defmodule SocialFeeds do
 
   """
   def get_next_meetup_event(opts \\ %{}) do
-    Cache.fetch(:next_meetup_event,
-                fn -> SocialFeeds.Meetup.ApiClient.get_next_event() end,
-                opts)
+    Cache.fetch(:next_meetup_event, fn -> SocialFeeds.Meetup.ApiClient.get_next_event() end, opts)
   end
 
   @doc """
@@ -51,8 +49,6 @@ defmodule SocialFeeds do
 
   """
   def get_new_yt_videos(opts \\ %{}) do
-    Cache.fetch(:new_videos,
-                fn -> SocialFeeds.Youtube.ApiClient.get_new_videos() end,
-                opts)
+    Cache.fetch(:new_videos, fn -> SocialFeeds.Youtube.ApiClient.get_new_videos() end, opts)
   end
 end

--- a/apps/social_feeds/lib/social_feeds/cache.ex
+++ b/apps/social_feeds/lib/social_feeds/cache.ex
@@ -60,6 +60,7 @@ defmodule SocialFeeds.Cache do
   """
   def fetch(key, default_value_function, opts) do
     expires_in = opts[:cache_ttl_in_msec] || @default_expiry_in_msec
+
     case get(key) do
       :not_found -> set(key, default_value_function.(), expires_in)
       {:found, result} -> result
@@ -95,14 +96,19 @@ defmodule SocialFeeds.Cache do
   Returns {:found, value} if the key is stored and still valid.
   """
   def handle_call({:get, key}, _from, state) do
-    value = case Map.fetch(state, key) do
-      :error -> :not_found
-      {:ok, result} -> if Entry.expired?(result) do
-        :not_found
-      else
-        {:found, result.value}
+    value =
+      case Map.fetch(state, key) do
+        :error ->
+          :not_found
+
+        {:ok, result} ->
+          if Entry.expired?(result) do
+            :not_found
+          else
+            {:found, result.value}
+          end
       end
-    end
+
     {:reply, value, state}
   end
 

--- a/apps/social_feeds/lib/social_feeds/meetup/api_client.ex
+++ b/apps/social_feeds/lib/social_feeds/meetup/api_client.ex
@@ -1,4 +1,4 @@
-if Mix.env == :test || Mix.env == :travis do
+if Mix.env() == :test || Mix.env() == :travis do
   Code.require_file("../../../test/api_clients/meetup_api_http_client.exs", __DIR__)
 end
 
@@ -49,7 +49,7 @@ defmodule SocialFeeds.Meetup.ApiClient do
   @http Application.get_env(:social_feeds, :meetup_api_client)[:http_client] || :httpc
   defp fetch_meetups(opts) do
     url = String.to_charlist(meetup_events_url() <> "?" <> URI.encode_query(opts))
-    Logger.info "Meetup API: requesting #{url}"
+    Logger.info("Meetup API: requesting #{url}")
 
     case @http.request(url) do
       {:ok, {_, _, body}} -> Poison.decode!(body)

--- a/apps/social_feeds/lib/social_feeds/youtube/api_client.ex
+++ b/apps/social_feeds/lib/social_feeds/youtube/api_client.ex
@@ -1,4 +1,4 @@
-if Mix.env == :test do
+if Mix.env() == :test do
   Code.require_file("../../../test/api_clients/youtube_api_http_client.exs", __DIR__)
 end
 
@@ -44,8 +44,8 @@ defmodule SocialFeeds.Youtube.ApiClient do
   @http Application.get_env(:social_feeds, :youtube_api_client)[:http_client] || :httpc
   defp fetch_videos(opts) do
     opts = Map.merge(opts, %{channelId: channel_id(), key: api_key()})
-    url  = youtube_activities_url() <> "?" <> URI.encode_query(opts)
-    Logger.info "YouTube API: requesting #{redact_sensitive_data(url)}"
+    url = youtube_activities_url() <> "?" <> URI.encode_query(opts)
+    Logger.info("YouTube API: requesting #{redact_sensitive_data(url)}")
 
     case @http.request(String.to_charlist(url)) do
       {:ok, {{_http_version, 200, _reason}, _headers, body}} -> Poison.decode!(body)["items"]

--- a/apps/social_feeds/mix.exs
+++ b/apps/social_feeds/mix.exs
@@ -10,7 +10,7 @@ defmodule SocialFeeds.Mixfile do
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
       elixir: "~> 1.6.4",
-      start_permanent: Mix.env == :prod,
+      start_permanent: Mix.env() == :prod,
       deps: deps()
     ]
   end

--- a/apps/social_feeds/test/api_clients/meetup_api_http_client.exs
+++ b/apps/social_feeds/test/api_clients/meetup_api_http_client.exs
@@ -6,6 +6,7 @@ defmodule SocialFeeds.Test.MeetupApiHttpClient do
 
   def request(url) do
     url = to_string(url)
+
     cond do
       String.contains?(url, "scroll=next_upcoming") -> {:ok, {[], [], @upcoming_meetups_json}}
       String.contains?(url, "error=true") -> {:error, {}}

--- a/apps/social_feeds/test/api_clients/youtube_api_http_client.exs
+++ b/apps/social_feeds/test/api_clients/youtube_api_http_client.exs
@@ -5,6 +5,7 @@ defmodule SocialFeeds.Test.YoutubeApiHttpClient do
 
   def request(url) do
     url = to_string(url)
+
     if String.contains?(url, "error=true") do
       {:error, {}}
     else

--- a/apps/social_feeds/test/meetup/api_client_test.exs
+++ b/apps/social_feeds/test/meetup/api_client_test.exs
@@ -8,6 +8,7 @@ defmodule SocialFeeds.Meetup.ApiClientTest do
     @tag :capture_log
     test "returns the next meetup_event" do
       {:ok, expected_time, _offset} = DateTime.from_iso8601("2017-10-11 22:30:00Z")
+
       event = %Event{
         name: "Montreal Elixir Meetup",
         utc_datetime: expected_time,
@@ -23,7 +24,7 @@ defmodule SocialFeeds.Meetup.ApiClientTest do
   describe "get_events/1" do
     @tag :capture_log
     test "returns list of Events" do
-      result = ApiClient.get_events() |> Enum.map(&(&1.name))
+      result = ApiClient.get_events() |> Enum.map(& &1.name)
 
       assert result == ["Meetup 1", "Meetup 2"]
     end

--- a/apps/social_feeds/test/social_feeds_test.exs
+++ b/apps/social_feeds/test/social_feeds_test.exs
@@ -11,6 +11,7 @@ defmodule SocialFeedsTest do
     @tag :capture_log
     test "returns the next meetup_event" do
       {:ok, expected_time, _offset} = DateTime.from_iso8601("2017-10-11 22:30:00Z")
+
       event = %SocialFeeds.Meetup.Event{
         name: "Montreal Elixir Meetup",
         utc_datetime: expected_time,

--- a/apps/social_feeds/test/youtube/api_client_test.exs
+++ b/apps/social_feeds/test/youtube/api_client_test.exs
@@ -18,6 +18,7 @@ defmodule SocialFeeds.Youtube.ApiClientTest do
         url: "https://youtube.com/watch?v=y25Suot7vto",
         img_url: "https://i.ytimg.com/vi/y25Suot7vto/default.jpg"
       }
+
       resp = ApiClient.get_new_videos()
 
       assert List.first(resp) == video
@@ -33,7 +34,7 @@ defmodule SocialFeeds.Youtube.ApiClientTest do
         "Montreal Elixir: Community Update"
       ]
 
-      result = ApiClient.get_videos() |> Enum.map(&(&1.title))
+      result = ApiClient.get_videos() |> Enum.map(& &1.title)
 
       assert result == titles
     end

--- a/apps/twitter/lib/twitter/adapter.ex
+++ b/apps/twitter/lib/twitter/adapter.ex
@@ -5,10 +5,10 @@ defmodule Twitter.Adapter do
   @doc """
   Returns a list of existing tweets in reverse order (most recent one first).
   """
-  @callback fetch_user_timeline() :: [Tweet.t]
+  @callback fetch_user_timeline() :: [Tweet.t()]
 
   @doc """
   Returns a stream of timeline events (new tweets, deleted tweets, ...).
   """
-  @callback get_user_stream() :: Stream.t
+  @callback get_user_stream() :: Stream.t()
 end

--- a/apps/twitter/lib/twitter/adapter/ex_twitter.ex
+++ b/apps/twitter/lib/twitter/adapter/ex_twitter.ex
@@ -26,18 +26,18 @@ defmodule Twitter.Adapter.ExTwitter do
     defp valid_message(_message), do: false
   end
 
-  @spec fetch_user_timeline() :: [Twitter.Tweet.t]
+  @spec fetch_user_timeline() :: [Twitter.Tweet.t()]
   def fetch_user_timeline do
-    ExTwitter.user_timeline
+    ExTwitter.user_timeline()
     |> Enum.map(&State.convert/1)
   end
 
-  @spec get_user_stream() :: Stream.t
+  @spec get_user_stream() :: Stream.t()
   def get_user_stream do
     options = [with: :user, receive_messages: true, timeout: :infinity]
 
     options
-    |> ExTwitter.stream_user
-    |> State.filter_stream
+    |> ExTwitter.stream_user()
+    |> State.filter_stream()
   end
 end

--- a/apps/twitter/lib/twitter/adapter/fake.ex
+++ b/apps/twitter/lib/twitter/adapter/fake.ex
@@ -5,7 +5,7 @@ defmodule Twitter.Adapter.Fake do
   # Public interface
 
   def start_link(_opts \\ []) do
-    GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
   def init(:ok) do
@@ -15,12 +15,12 @@ defmodule Twitter.Adapter.Fake do
     {:ok, %{queue: queue, tweets: []}}
   end
 
-  @spec fetch_user_timeline() :: [Twitter.Tweet.t]
+  @spec fetch_user_timeline() :: [Twitter.Tweet.t()]
   def fetch_user_timeline do
     GenServer.call(__MODULE__, :tweets)
   end
 
-  @spec get_user_stream() :: Stream.t
+  @spec get_user_stream() :: Stream.t()
   def get_user_stream do
     GenServer.call(__MODULE__, :get_stream)
   end

--- a/apps/twitter/lib/twitter/application.ex
+++ b/apps/twitter/lib/twitter/application.ex
@@ -9,7 +9,7 @@ defmodule Twitter.Application do
     PubSub.start_link()
 
     # List all child processes to be supervised
-    children = workers(Mix.env)
+    children = workers(Mix.env())
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
@@ -18,6 +18,7 @@ defmodule Twitter.Application do
   end
 
   defp workers(:test), do: []
+
   defp workers(_env) do
     [
       {Twitter.Timeline, []}

--- a/apps/twitter/lib/twitter/timeline.ex
+++ b/apps/twitter/lib/twitter/timeline.ex
@@ -28,7 +28,7 @@ defmodule Twitter.Timeline do
   @doc """
   Returns the tweets, the first one being the most recent one.
   """
-  @spec tweets :: [Tweet.t]
+  @spec tweets :: [Tweet.t()]
   def tweets do
     GenServer.call(__MODULE__, :list)
   end
@@ -78,8 +78,9 @@ defmodule Twitter.Timeline do
 
   defp determine_call(%Tweet{} = tweet), do: {:push, tweet}
   defp determine_call(%TweetDeletion{tweet_id: tweet_id}), do: {:remove, tweet_id}
+
   defp determine_call(message) do
-    Logger.debug fn -> "Unhandled message #{inspect(message)}" end
+    Logger.debug(fn -> "Unhandled message #{inspect(message)}" end)
     :noop
   end
 end

--- a/apps/twitter/lib/twitter/tweet.ex
+++ b/apps/twitter/lib/twitter/tweet.ex
@@ -1,6 +1,6 @@
 defmodule Twitter.Tweet do
   @moduledoc false
-  defstruct [id: nil, text: nil, timestamp: nil]
+  defstruct id: nil, text: nil, timestamp: nil
 
   @type t :: %__MODULE__{}
 end

--- a/apps/twitter/lib/twitter/tweet_deletion.ex
+++ b/apps/twitter/lib/twitter/tweet_deletion.ex
@@ -1,6 +1,6 @@
 defmodule Twitter.TweetDeletion do
   @moduledoc false
-  defstruct [tweet_id: nil]
+  defstruct tweet_id: nil
 
   @type t :: %__MODULE__{}
 end

--- a/apps/twitter/mix.exs
+++ b/apps/twitter/mix.exs
@@ -10,7 +10,7 @@ defmodule Twitter.Mixfile do
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
       elixir: "~> 1.6.4",
-      start_permanent: Mix.env == :prod,
+      start_permanent: Mix.env() == :prod,
       deps: deps()
     ]
   end

--- a/apps/twitter/test/twitter/adapter/ex_twitter_state_test.exs
+++ b/apps/twitter/test/twitter/adapter/ex_twitter_state_test.exs
@@ -24,10 +24,12 @@ defmodule Twitter.Adapter.ExTwitter.StateTest do
       %ExTwitter.Model.User{},
       {:friends, %{friends: [343, 22, 344]}}
     ]
+
     wanted_message = [
       %ExTwitter.Model.Tweet{},
-      %ExTwitter.Model.DeletedTweet{status: %{id: ":id:"}},
+      %ExTwitter.Model.DeletedTweet{status: %{id: ":id:"}}
     ]
+
     stream = Stream.cycle(unwanted_messages ++ wanted_message)
 
     tweets_stream = Adapter.ExTwitter.State.filter_stream(stream)

--- a/apps/twitter/test/twitter/timeline_test.exs
+++ b/apps/twitter/test/twitter/timeline_test.exs
@@ -7,7 +7,7 @@ defmodule Twitter.TimelineTest do
     adapter = Twitter.Adapter.Fake
     {:ok, pid} = adapter.start_link()
 
-    on_exit fn -> assert_down(pid) end
+    on_exit(fn -> assert_down(pid) end)
 
     [adapter: adapter]
   end
@@ -21,13 +21,13 @@ defmodule Twitter.TimelineTest do
 
       {:ok, timeline} = Timeline.start_link(adapter: adapter)
 
-      tweets = Timeline.tweets
+      tweets = Timeline.tweets()
 
       assert length(tweets) == 2
       first_tweet = List.first(tweets)
       assert %Tweet{text: ":tweet-2:"} = first_tweet
 
-      on_exit fn -> assert_down(timeline) end
+      on_exit(fn -> assert_down(timeline) end)
     end
   end
 
@@ -38,7 +38,7 @@ defmodule Twitter.TimelineTest do
       PubSub.subscribe(self(), topic)
 
       {:ok, timeline} = Timeline.start_link(adapter: adapter, topic: topic)
-      on_exit fn -> assert_down(timeline) end
+      on_exit(fn -> assert_down(timeline) end)
 
       :ok
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MontrealElixir.Umbrella.Mixfile do
   def project do
     [
       apps_path: "apps",
-      start_permanent: Mix.env == :prod,
+      start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: aliases(),
       preferred_cli_env: [
@@ -16,6 +16,7 @@ defmodule MontrealElixir.Umbrella.Mixfile do
   def aliases do
     [
       "project.check": [
+        "format --dry-run --check-formatted",
         "compile --force --warnings-as-errors",
         "test",
         "credo --strict"


### PR DESCRIPTION
### Requirements

* Enforce mix format during travis run
* Configure the formatter to work with the app

### Description of the Change

Elixir provide tools to format the code in a standard way.

This change request allows us to have a base configuration so we can use the `mix format` task.
We also enforce it in the `mix project.check` task so that anyone that contributes to the project sends code that is correctly formatted.
