### PR TITLE
H15 "Idle connection" error

### DIFF
--- a/apps/montreal_elixir_web/lib/montreal_elixir_web/endpoint.ex
+++ b/apps/montreal_elixir_web/lib/montreal_elixir_web/endpoint.ex
@@ -1,52 +1,43 @@
 defmodule MontrealElixirWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :montreal_elixir_web
 
-  socket("/socket", MontrealElixirWeb.UserSocket, websocket: true)
+  socket "/socket", MontrealElixirWeb.UserSocket, websocket: true
 
   # Serve at "/" the static files from "priv/static" directory.
   #
   # You should set gzip to true if you are running phoenix.digest
   # when deploying your static files in production.
-  plug(
-    Plug.Static,
+  plug Plug.Static,
     at: "/",
     from: :montreal_elixir_web,
     gzip: false,
     only: ~w(css fonts images img js favicon.ico robots.txt)
-  )
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.
   if code_reloading? do
-    socket("/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket)
-    plug(Phoenix.LiveReloader)
-    plug(Phoenix.CodeReloader)
+    socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
+    plug Phoenix.LiveReloader
+    plug Phoenix.CodeReloader
   end
 
-  plug(Plug.RequestId)
-  plug(Plug.Logger)
+  plug Plug.RequestId
+  plug Plug.Logger
 
-  plug(
-    Plug.Parsers,
+  plug Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
     json_decoder: Poison
-  )
 
-  plug(Plug.MethodOverride)
-  plug(Plug.Head)
+  plug Plug.MethodOverride
+  plug Plug.Head
 
   # The session will be stored in the cookie and signed,
   # this means its contents can be read but not tampered with.
   # Set :encryption_salt if you would also like to encrypt it.
-  plug(
-    Plug.Session,
-    store: :cookie,
-    key: "_montreal_elixir_web_key",
-    signing_salt: "e9FWV39l"
-  )
+  plug Plug.Session, store: :cookie, key: "_montreal_elixir_web_key", signing_salt: "e9FWV39l"
 
-  plug(MontrealElixirWeb.Router)
+  plug MontrealElixirWeb.Router
 
   @doc """
   Callback invoked for dynamically configuring the endpoint.

--- a/apps/montreal_elixir_web/lib/montreal_elixir_web/endpoint.ex
+++ b/apps/montreal_elixir_web/lib/montreal_elixir_web/endpoint.ex
@@ -1,7 +1,10 @@
 defmodule MontrealElixirWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :montreal_elixir_web
 
-  socket "/socket", MontrealElixirWeb.UserSocket, websocket: true
+  socket "/socket", MontrealElixirWeb.UserSocket,
+    websocket: true,
+    websocket: [timeout: 45_000],
+    longpoll: false
 
   # Serve at "/" the static files from "priv/static" directory.
   #


### PR DESCRIPTION
```
Dec 31 06:43:53 montreal-elixir-production heroku/router: at=error code=H15 desc="Idle connection" method=GET path="/socket/websocket?token=undefined&vsn=2.0.0" host=montrealelixir.ca request_id=REDACTED fwd="135.23.196.187" dyno=web.1 connect=0ms service=335706ms status=503 bytes= protocol=https
```

https://hexdocs.pm/phoenix/heroku.html#making-our-project-ready-for-heroku

> Finally, if you plan on using websockets, then we will need to decrease the timeout for the websocket transport in lib/hello_web/endpoint.ex.

```elixir
defmodule HelloWeb.Endpoint do
  use Phoenix.Endpoint, otp_app: :hello

  socket "/socket", HelloWeb.UserSocket,
    websocket: [timeout: 45_000],
    longpoll: false

  ...
end
```

> This ensures that any idle connections are closed by Phoenix before they reach Heroku's 55-second timeout window.

