### PR TITLE
Upgrade CircleCI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/elixir:1.12.2
+      - image: cimg/elixir:1.12.2
         environment:
           MIX_ENV: test
       - image: circleci/postgres:11.4-alpine


### PR DESCRIPTION
Base on the email received:

> You're currently using a legacy image that is not optimized for performance on CircleCI on the following project(s): 

> ['https://github.com/montrealelixir/website'] 

> Today we want to introduce our newest Elixir image, now available for all your Elixir projects. 

> CircleCI’s latest pre-built container images were designed from the ground up to help your team build more reliably. Our new images were built specifically for continuous integration projects and they are our most deterministic, performant, and efficient images yet. 

> Why migrate? 
> More deterministic: The newest images will be rebuilt only for security and critical-bugs, drastically reducing breaking changes from updates in legacy images.

> Faster build times: Our newest images get faster as our community uses them due to improved caching. Migrating to the new image is good for your builds and for the builds of the larger Elixir community.

> As of Dec 31, 2021, legacy images will no longer be supported on CircleCI. View more information on our image deprecation timeline here.


> Migrating from the Elixir legacy image to the newest image is a small config change. 

> circleci/elixir:1.12.0 -> cimg/elixir:1.12.0

> More information on how to update, including any possible changes in the image layers and support for variant tags can be found in the migration guide. Following the guide will also ensure that your update does not result in a breaking change. 
