### PR TITLE
Fix YouTube video feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ config/test.secret.exs
 .env
 .envrc
 .docker-sync
+
+/tmp

--- a/apps/social_feeds/lib/social_feeds/youtube/api_client.ex
+++ b/apps/social_feeds/lib/social_feeds/youtube/api_client.ex
@@ -47,8 +47,15 @@ defmodule SocialFeeds.Youtube.ApiClient do
     Logger.info("YouTube API: requesting #{redact_sensitive_data(url)}")
 
     case http().request(String.to_charlist(url)) do
-      {:ok, {{_http_version, 200, _reason}, _headers, body}} -> Poison.decode!(body)["items"]
-      _ -> []
+      {:ok, {{_http_version, 200, _reason}, _headers, body}} ->
+        Poison.decode!(body)["items"]
+
+      result ->
+        result
+        |> inspect
+        |> Logger.debug()
+
+        []
     end
   end
 

--- a/apps/social_feeds/lib/social_feeds/youtube/api_client.ex
+++ b/apps/social_feeds/lib/social_feeds/youtube/api_client.ex
@@ -21,7 +21,7 @@ defmodule SocialFeeds.Youtube.ApiClient do
 
   """
   def get_new_videos do
-    get_videos(%{maxResults: 3, part: "snippet,contentDetails"})
+    get_videos(%{maxResults: 3, part: "snippet", order: "date", type: "video"})
   end
 
   @doc """
@@ -43,7 +43,7 @@ defmodule SocialFeeds.Youtube.ApiClient do
 
   defp fetch_videos(opts) do
     opts = Map.merge(opts, %{channelId: channel_id(), key: api_key()})
-    url = youtube_activities_url() <> "?" <> URI.encode_query(opts)
+    url = youtube_search_url() <> "?" <> URI.encode_query(opts)
     Logger.info("YouTube API: requesting #{redact_sensitive_data(url)}")
 
     case http().request(String.to_charlist(url)) do
@@ -61,16 +61,17 @@ defmodule SocialFeeds.Youtube.ApiClient do
 
   defp to_video(video_map) do
     {:ok, published_at, _} = DateTime.from_iso8601(video_map["snippet"]["publishedAt"])
+    video_id = video_map["id"]["videoId"]
 
     %Video{
       title: video_map["snippet"]["title"],
-      url: youtube_watch_url() <> "?v=" <> video_map["contentDetails"]["upload"]["videoId"],
+      url: youtube_watch_url() <> "?v=" <> video_id,
       img_url: video_map["snippet"]["thumbnails"]["default"]["url"],
       published_at: published_at
     }
   end
 
-  defp youtube_activities_url, do: base_url() <> "/activities"
+  defp youtube_search_url, do: base_url() <> "/search"
   defp youtube_watch_url, do: public_url() <> "/watch"
 
   defp base_url, do: Application.get_env(:social_feeds, :youtube_api_client)[:youtube_api_url]

--- a/apps/social_feeds/test/api_clients/youtube_api_http_client.exs
+++ b/apps/social_feeds/test/api_clients/youtube_api_http_client.exs
@@ -1,7 +1,7 @@
 defmodule SocialFeeds.Test.YoutubeApiHttpClient do
   @moduledoc false
 
-  @activities_json File.read!("test/fixtures/youtube_get_activities.json")
+  @search_json File.read!("test/fixtures/youtube_get_search.json")
 
   def request(url) do
     url = to_string(url)
@@ -9,7 +9,7 @@ defmodule SocialFeeds.Test.YoutubeApiHttpClient do
     if String.contains?(url, "error=true") do
       {:error, {}}
     else
-      {:ok, {{"HTTP/1.1", 200, "OK"}, [], @activities_json}}
+      {:ok, {{"HTTP/1.1", 200, "OK"}, [], @search_json}}
     end
   end
 end

--- a/apps/social_feeds/test/fixtures/youtube_get_search.json
+++ b/apps/social_feeds/test/fixtures/youtube_get_search.json
@@ -1,5 +1,5 @@
 {
- "kind": "youtube#activityListResponse",
+ "kind": "youtube#searchListResponse",
  "etag": "\"cbz3lIQ2N25AfwNr-BdxUVxJ_QY/wqqxZoPyMtbST_5YW_XQCAPaV1E\"",
  "nextPageToken": "CAMQAA",
  "pageInfo": {
@@ -8,9 +8,12 @@
  },
  "items": [
   {
-   "kind": "youtube#activity",
+   "kind": "youtube#searchResult",
    "etag": "\"cbz3lIQ2N25AfwNr-BdxUVxJ_QY/Q0x_M3INjItqCemshqjDfJKo2aM\"",
-   "id": "VTE1MDU4MjM4MTI5NDI0ODAyODI5OTQwOA==",
+   "id": {
+     "kind": "youtube#video",
+     "videoId": "y25Suot7vto"
+    },
    "snippet": {
     "publishedAt": "2017-09-19T12:23:32.000Z",
     "channelId": "UCftyx5k7K_0a3wIGRtE2YQw",
@@ -42,20 +45,16 @@
       "width": 1280,
       "height": 720
      }
-    },
-    "channelTitle": "Montreal Elixir",
-    "type": "upload"
-   },
-   "contentDetails": {
-    "upload": {
-     "videoId": "y25Suot7vto"
     }
    }
   },
   {
-   "kind": "youtube#activity",
+   "kind": "youtube#searchResult",
    "etag": "\"cbz3lIQ2N25AfwNr-BdxUVxJ_QY/ytT0art7cB335isZfA2XVofFkxs\"",
-   "id": "VTE1MDU4MjM2NDE5NDI0ODAyODI5OTc5Mg==",
+   "id": {
+     "kind": "youtube#video",
+    "videoId": "iWCCThD040A"
+   },
    "snippet": {
     "publishedAt": "2017-09-19T12:20:41.000Z",
     "channelId": "UCftyx5k7K_0a3wIGRtE2YQw",
@@ -87,20 +86,16 @@
       "width": 1280,
       "height": 720
      }
-    },
-    "channelTitle": "Montreal Elixir",
-    "type": "upload"
-   },
-   "contentDetails": {
-    "upload": {
-     "videoId": "iWCCThD040A"
     }
    }
   },
   {
-   "kind": "youtube#activity",
+   "kind": "youtube#searchResult",
    "etag": "\"cbz3lIQ2N25AfwNr-BdxUVxJ_QY/3Ly_XM7ceLkPwQL648gerPVjeoY\"",
-   "id": "VTE1MDU4MjM0Njk5NDI0ODAyODMwMTMyOA==",
+   "id": {
+    "kind": "youtube#video",
+    "videoId": "S362bHXS8UI"
+   },
    "snippet": {
     "publishedAt": "2017-09-19T12:17:49.000Z",
     "channelId": "UCftyx5k7K_0a3wIGRtE2YQw",
@@ -132,13 +127,6 @@
       "width": 1280,
       "height": 720
      }
-    },
-    "channelTitle": "Montreal Elixir",
-    "type": "upload"
-   },
-   "contentDetails": {
-    "upload": {
-     "videoId": "S362bHXS8UI"
     }
    }
   }


### PR DESCRIPTION
The activity feed includes the creation of playlists which we don't want. Also, the shape of a playlist in the activity feed is different to that of the video object, causing the parsing logic to crash.

The proper API endpoint to use here is `search` and filter on `video`.